### PR TITLE
fix: follow symlink when searching for cases

### DIFF
--- a/Alltest
+++ b/Alltest
@@ -191,8 +191,7 @@ done
 cd "$root"
 
 # get setup to run tests
-#cases=$(find cases/ -maxdepth 1 -mindepth 1 -type d)
-mapfile -t cases_array < <(find cases/ -maxdepth 1 -mindepth 1 -type d)
+mapfile -t cases_array < <(find -L cases/ -maxdepth 1 -mindepth 1 -type d)
 if [ ${#cases_array[@]} -eq 0 ]; then
     echo "No cases found to run tests"
     exit 1


### PR DESCRIPTION
Hello,

At least from my undestanding, I believe that the [How to use this repo](https://github.com/FoamScience/foamUT/blob/d5ea536cc67f29834cdc656961312a9f693f26ac/README.md#how-to-use-this-repo) implies that one could create a symbolic link for user's OpenFOAM cases in the same manner that it can be done for tests. I tried it in this manner, but I couldn't get the this expected behavior.

I have tracked down the cause to ```find``` command not following links. In that case, the simple addition of ```-L``` was enough for the correct inclusion of my cases to the test suite. I am creating this PR for you to evaluate whether it does make sense.

Btw, thank your for your time and this useful framework!